### PR TITLE
Updated the Go version from 1.22 to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enthus-golang/bmecat-1.2
 
-go 1.22
+go 1.24
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
This pull request updates the Go module version in the `go.mod` file to align with a newer Go release.

Version update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.22` to `1.24` to ensure compatibility with the latest features and improvements in Go.